### PR TITLE
fix conc manager to handle molecule IDs

### DIFF
--- a/frontend/src/components/FlowModel.js
+++ b/frontend/src/components/FlowModel.js
@@ -110,7 +110,9 @@ const FlowModel = (props) => {
             setMolecules(mList);
             setEdges((edges) =>
                 edges.map((edge) => {
-                    edge.style = {strokeWidth: mList[edge.data.molecule_id].value * 10, stroke: 'red'};
+                    if (mList[edge.data.molecule_id]) {
+                        edge.style = {strokeWidth: mList[edge.data.molecule_id].value * 10, stroke: 'red'};
+                    }
                     return edge;
                 })
             );

--- a/frontend/src/components/FlowModel.js
+++ b/frontend/src/components/FlowModel.js
@@ -40,7 +40,7 @@ const FlowModel = (props) => {
 	let [nodes, setNodes, onNodesChange] = useNodesState([]);
 	let [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
-    // molecules[] = [{"title": "ATP", "value": 10}]
+    // molecules[id] = {"title": "ATP", "value": 10}
     let [molecules, setMolecules] = useState([]);
 
     /**
@@ -101,29 +101,25 @@ const FlowModel = (props) => {
         const enzymesForSliders = parseEnzymesForSliders(newPathway);
         props.concentrationManager.addListener((moleculeConcentrations) => {
             let mList = [];
-            for (const m in moleculeConcentrations) {
-                mList.push({
-                    "title": m,
-                    "value": moleculeConcentrations[m]
-                });
+            for (const [id, data] of Object.entries(moleculeConcentrations)) {
+                mList[id] = {
+                    "title": data.title,
+                    "value": data.value
+                };
             }
+            setMolecules(mList);
             setEdges((edges) =>
                 edges.map((edge) => {
-                    for (const item of mList) {
-                        if (edge.data.molecule_id === item["title"]) {
-                            edge.style = {strokeWidth: item["value"] * 10, stroke: 'red'};
-                        }
-                    }
+                    edge.style = {strokeWidth: mList[edge.data.molecule_id].value * 10, stroke: 'red'};
                     return edge;
                 })
             );
-            setMolecules(mList);
         });
         props.concentrationManager.parseEnzymes(enzymesForSliders);
     }
 
-    const handleConcentrationChange = (title, value) => {
-        props.concentrationManager.setConcentration(title, value);
+    const handleConcentrationChange = (id, value) => {
+        props.concentrationManager.setConcentration(id, value);
     }
 
     /**

--- a/frontend/src/components/PathwayView.js
+++ b/frontend/src/components/PathwayView.js
@@ -9,8 +9,6 @@ import Error from "./Error";
 //import Restore from './Restore';
 import './css/PathwayView.css'
 
-
-//import { buildFlow, findMolecules, findSliders } from './utils/pathwayComponentUtils';
 import userInputInteractionList from './PathwayInteractiveComponent';
 import ConcentrationManager from './utils/ConcentrationManager';
 
@@ -18,14 +16,7 @@ export default class PathwayView extends Component {
   constructor(props) {
     super(props);
 
-    // this.handleConcChange = this.handleConcChange.bind(this)
-
-    // setup observers for all inputs which affect the pathway 
-    //  this observer list will be passed into each of the non-modelArea 
-    //  components
-    this.pathwayUserInputSubList = new userInputInteractionList();
     this.concentrationManager = new ConcentrationManager();
-    
   }
 
   render() {
@@ -44,10 +35,6 @@ export default class PathwayView extends Component {
                               />
                               
                             </div>
-
-                            {/* <div className="col-md-auto" id="RightSideBarAreaCol">
-                              <RightSideBarArea dataObserver={ this.pathwayUserInputSubList }/>
-                            </div> */}
                           </div>
                         </div>
 

--- a/frontend/src/components/SliderSideBar.js
+++ b/frontend/src/components/SliderSideBar.js
@@ -20,11 +20,11 @@ const SliderSideBar = (props) => {
         // close all others when another slider has been set to open
         }
     }
-    const sliderItems = props.molecules.map((molecule) => 
-        <li key={molecule.title}>
+    const sliderItems = Object.entries(props.molecules).map(([id, data]) => 
+        <li key={id}>
             <Slider 
-                title={ molecule.title }
-                value={ molecule.value.toFixed(2) }
+                title={ data.title }
+                value={ data.value.toFixed(2) }
                 handleConcentrationChange={ props.handleConcentrationChange } 
             />
         </li>

--- a/frontend/src/components/utils/ConcentrationManager.js
+++ b/frontend/src/components/utils/ConcentrationManager.js
@@ -12,7 +12,7 @@ class ConcentrationManager {
      * @constructor
      */
     constructor() {
-        this.moleculeConcentrations = [];
+        this.moleculeConcentrations = []; // [{ID: {"title": string, "value": float}}]
         this.enzymes = [];
         this.listeners = [];
         this.interval = null;
@@ -30,13 +30,13 @@ class ConcentrationManager {
         this.moleculeConcentrations = [];
         for (const enzyme of enzymes) {
             for (const substrate of enzyme.substrates) {
-                this.moleculeConcentrations[substrate] = 1;
+                this.moleculeConcentrations[substrate.id] = {"title": substrate.title, "value": 1};
             }
             for (const product of enzyme.products) {
-                this.moleculeConcentrations[product] = 1;
+                this.moleculeConcentrations[product.id] = {"title": product.title, "value": 1};
             }
             for (const cofactor of enzyme.cofactors) {
-                this.moleculeConcentrations[cofactor] = 1;
+                this.moleculeConcentrations[cofactor.id] = {"title": cofactor.title, "value": 1};
             }
         }
         this.enzymes = enzymes;
@@ -53,20 +53,20 @@ class ConcentrationManager {
             let minSubstrateConc = null;
             for (const substrate of enzyme.substrates) {
                 if (!minSubstrateConc) {
-                    minSubstrateConc = cachedConcentrations[substrate];
+                    minSubstrateConc = cachedConcentrations[substrate.id].value;
                 }
                 if (cachedConcentrations[substrate] < minSubstrateConc) {
-                    minSubstrateConc = cachedConcentrations[substrate];
+                    minSubstrateConc = cachedConcentrations[substrate.id].value;
                 }
             }
             for (const substrate of enzyme.substrates) {
                 if (minSubstrateConc) {
-                    this.moleculeConcentrations[substrate] -= minSubstrateConc * 0.1;
+                    this.moleculeConcentrations[substrate.id].value -= minSubstrateConc * 0.1;
                 }
             }
             for (const product of enzyme.products) {
                 if (minSubstrateConc) {
-                    this.moleculeConcentrations[product] += minSubstrateConc * 0.1;
+                    this.moleculeConcentrations[product.id].value += minSubstrateConc * 0.1;
                 }
             }
         }
@@ -113,12 +113,12 @@ class ConcentrationManager {
 
     /**
      * Manually set the concentration of a molecule
-     * @param {string} title 
-     * @param {int} value 
+     * @param {int} id
+     * @param {int} value
      */
-    setConcentration(title, value) {
+    setConcentration(id, value) {
         if (this.moleculeConcentrations) {
-            this.moleculeConcentrations[title] = parseFloat(value);
+            this.moleculeConcentrations[id].value = parseFloat(value);
             this.notifyListeners();
         } else {
             console.log("No Concentrations");

--- a/frontend/src/components/utils/ConcentrationManager.test.js
+++ b/frontend/src/components/utils/ConcentrationManager.test.js
@@ -4,39 +4,39 @@ describe('concentrations', () => {
     test('init', () => {
         let enzymes = [
             {
-                substrates: ["G"],
-                products: ["G6"],
-                cofactors: ["Na"]
+                substrates: [{"id": 1, "title": "G"}],
+                products: [{"id": 2, "title": "G6"}],
+                cofactors: [{"id": 3, "title": "Na"}]
             }
         ]
         let c = new ConcentrationManager();
         c.parseEnzymes(enzymes);
-        expect(c.moleculeConcentrations["G"]).toBe(1);
-        expect(c.moleculeConcentrations["G6"]).toBe(1);
-        expect(c.moleculeConcentrations["Na"]).toBe(1);
+        expect(c.moleculeConcentrations[1].value).toBe(1);
+        expect(c.moleculeConcentrations[2].value).toBe(1);
+        expect(c.moleculeConcentrations[3].value).toBe(1);
     });
     
     test('update', () => {
         let enzymes = [
             {
-                substrates: ["G"],
-                products: ["G6"],
-                cofactors: ["Na"]
+                substrates: [{"id": 1, "title": "G"}],
+                products: [{"id": 2, "title": "G6"}],
+                cofactors: [{"id": 3, "title": "Na"}]
             }
         ]
         let c = new ConcentrationManager();
         c.parseEnzymes(enzymes);
         c.updateConcentrations();
-        expect(c.moleculeConcentrations["G"]).toBe(0.9);
-        expect(c.moleculeConcentrations["G6"]).toBe(1.1);
+        expect(c.moleculeConcentrations[1].value).toBe(0.9);
+        expect(c.moleculeConcentrations[2].value).toBe(1.1);
     });
     
     test('addListener', () => {
         let enzymes = [
             {
-                substrates: ["G"],
-                products: ["G6"],
-                cofactors: ["Na"]
+                substrates: [{"id": 1, "title": "G"}],
+                products: [{"id": 2, "title": "G6"}],
+                cofactors: [{"id": 3, "title": "Na"}]
             }
         ]
         let c = new ConcentrationManager();
@@ -50,9 +50,9 @@ describe('concentrations', () => {
     test('removeListener', () => {
         let enzymes = [
             {
-                substrates: ["G"],
-                products: ["G6"],
-                cofactors: ["Na"]
+                substrates: [{"id": 1, "title": "G"}],
+                products: [{"id": 2, "title": "G6"}],
+                cofactors: [{"id": 3, "title": "Na"}]
             }
         ]
         let c = new ConcentrationManager();
@@ -68,17 +68,17 @@ describe('concentrations', () => {
     test('setConcentration', () => {
         let enzymes = [
             {
-                substrates: ["G"],
-                products: ["G6"],
-                cofactors: ["Na"]
+                substrates: [{"id": 1, "title": "G"}],
+                products: [{"id": 2, "title": "G6"}],
+                cofactors: [{"id": 3, "title": "Na"}]
             }
         ]
         let c = new ConcentrationManager();
         c.parseEnzymes(enzymes);
         let listener_a = jest.fn();
         c.addListener(listener_a);
-        c.setConcentration("G", 0.2);
-        expect(c.moleculeConcentrations["G"]).toBe(0.2);
+        c.setConcentration(1, 0.2);
+        expect(c.moleculeConcentrations[1].value).toBe(0.2);
         expect(listener_a).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/components/utils/pathwayComponentUtils.js
+++ b/frontend/src/components/utils/pathwayComponentUtils.js
@@ -189,7 +189,10 @@ export function parseEnzymesForSliders(pathwayData) {
                 return o.id === parseInt(substrate);
             });
             if (m.length > 0) {
-                e["substrates"].push(m[0]["id"]);
+                e["substrates"].push({
+                    "id": m[0]["id"],
+                    "title": m[0]["abbreviation"]
+                });
             }
         }
         for (const product of enzyme["products"]) {
@@ -197,7 +200,10 @@ export function parseEnzymesForSliders(pathwayData) {
                 return o.id === product;
             });
             if (m.length > 0) {
-                e["products"].push(m[0]["id"]);
+                e["products"].push({
+                    "id": m[0]["id"],
+                    "title": m[0]["abbreviation"]
+                });
             }
         }
         for (const cofactor of enzyme["cofactors"]) {
@@ -205,7 +211,10 @@ export function parseEnzymesForSliders(pathwayData) {
                 return o.id === cofactor;
             });
             if (m.length > 0) {
-                e["cofactors"].push(m[0]["id"]);
+                e["cofactors"].push({
+                    "id": m[0]["id"],
+                    "title": m[0]["abbreviation"]
+                });
             }
         }
         enzymes.push(e);

--- a/frontend/src/components/utils/pathwayComponentUtils.test.js
+++ b/frontend/src/components/utils/pathwayComponentUtils.test.js
@@ -26,9 +26,9 @@ describe('pathwayComponentUtils', () => {
         let enzymes = parseEnzymesForSliders(data);
         expect(enzymes.length).toEqual(1);
         for (const e of enzymes) {
-            expect(e["substrates"]).toContain("m1");
-            expect(e["products"]).toContain("m2");
-            expect(e["cofactors"]).toContain("m3");
+            expect(e["substrates"]).toContainEqual({"id": 56, "title": "m1"});
+            expect(e["products"]).toContainEqual({"id": 57, "title": "m2"});
+            expect(e["cofactors"]).toContainEqual({"id": 58, "title": "m3"});
         }
     });
 });


### PR DESCRIPTION
Changed molecules in Concentration manager to be `{ID: {"title": string, "value": float}}` so you can do `molecules[id].value` or `molecules[id].title`